### PR TITLE
Update channels.json

### DIFF
--- a/channels.json
+++ b/channels.json
@@ -1,6 +1,15 @@
 [
     {
         "id": 1,
+        "stream_id": "ae",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "A&E",
+        "name": "A&E",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 2,
         "stream_id": "abc",
         "tvguide_id": "9233011874",
         "ustvgo_id": "ABC",
@@ -9,147 +18,291 @@
         "language": "en"
     },
     {
-        "id": 2,
-        "stream_id": "bet",
-        "tvguide_id": "9233000226",
-        "ustvgo_id": "BET",
-        "name": "BET",
-        "category": "Lifestyle",
-        "language": "en"
-    },
-    {
         "id": 3,
-        "stream_id": "cmt-country-music-television",
-        "tvguide_id": "9233000169",
-        "ustvgo_id": "CMT",
-        "name": "CMT",
+        "stream_id": "cbs",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "CBS",
+        "name": "CBS",
         "category": "Entertainment",
         "language": "en"
     },
     {
         "id": 4,
+        "stream_id": "espn-20220618",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "ESPN",
+        "name": "ESPN",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 5,
+        "stream_id": "espn-news",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "ESPNNews",
+        "name": "ESPN News",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 6,
+        "stream_id": "espn2-20220717",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "ESPN2",
+        "name": "ESPN2",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 7,
+        "stream_id": "espnu-20220717",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "ESPNU",
+        "name": "ESPNU",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 8,
+        "stream_id": "fox-network",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "FOX",
+        "name": "FOX",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 9,
+        "stream_id": "fox-news-hd",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "FOXNEWS",
+        "name": "Fox News",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 10,
+        "stream_id": "fox-sports-1-20220618",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "FS1",
+        "name": "FS1",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 11,
+        "stream_id": "fox-sports-2-20220618",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "FS2",
+        "name": "FS2",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 12,
+        "stream_id": "golf-channel",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "Golf",
+        "name": "Golf Channel",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 13,
+        "stream_id": "hgtv",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "HGTV",
+        "name": "HGTV",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 14,
+        "stream_id": "history-channel",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "History",
+        "name": "History Channel",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 15,
+        "stream_id": "fx-live",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "FX",
+        "name": "FX",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 16,
+        "stream_id": "hbo-02032021",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "HBO",
+        "name": "HBO",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 17,
+        "stream_id": "nbc-20201017",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "NBC",
+        "name": "NBC",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 18,
+        "stream_id": "nbcsn-20201106",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "NBCSN",
+        "name": "NBC Sports",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 19,
+        "stream_id": "nfl-network",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "NFL",
+        "name": "NFL Network",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 20,
+        "stream_id": "nhl-network",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "NHL",
+        "name": "NHL Network",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 21,
+        "stream_id": "sec-network",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "SEC",
+        "name": "SEC Network",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 22,
+        "stream_id": "showtime",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "Showtime",
+        "name": "Showtime",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 23,
+        "stream_id": "starz",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "Starz",
+        "name": "Starz",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 24,
+        "stream_id": "tbs",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "TBS",
+        "name": "TBS",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 25,
+        "stream_id": "tnt",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "TNT",
+        "name": "TNT",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 26,
+        "stream_id": "travel-channel",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "Travel",
+        "name": "Travel Channel",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 27,
+        "stream_id": "trutv",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "TruTV",
+        "name": "TruTV",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 28,
+        "stream_id": "usa-network",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "USA",
+        "name": "USA",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 29,
+        "stream_id": "amc",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "AMC",
+        "name": "AMC",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 30,
+        "stream_id": "animal-planet-20211102",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "Animal",
+        "name": "Animal Planet",
+        "category": "Entertainment",
+        "language": "en"
+    },
+    {
+        "id": 31,
         "stream_id": "comedy-central",
-        "tvguide_id": "9233009509",
+        "tvguide_id": "9233011874",
         "ustvgo_id": "Comedy",
         "name": "Comedy Central",
         "category": "Entertainment",
         "language": "en"
     },
     {
-        "id": 5,
-        "stream_id": "disney-channel",
-        "tvguide_id": "9200011893",
-        "ustvgo_id": "Disney",
-        "name": "Disney",
-        "category": "Kids",
-        "language": "en"
-    },
-    {
-        "id": 6,
-        "stream_id": "disney-junior",
-        "tvguide_id": "9200016560",
-        "ustvgo_id": "DisneyJr",
-        "name": "Disney Junior",
-        "category": "Kids",
-        "language": "en"
-    },
-    {
-        "id": 7,
-        "stream_id": "disney-xd",
-        "tvguide_id": "9200004852",
-        "ustvgo_id": "DisneyXD",
-        "name": "Disney XD",
-        "category": "Kids",
-        "language": "en"
-    },
-    {
-        "id": 8,
-        "stream_id": "espn-20210711",
-        "tvguide_id": "9233007996",
-        "ustvgo_id": "ESPN",
-        "name": "ESPN",
-        "category": "Sports",
-        "language": "en"
-    },
-    {
-        "id": 9,
-        "stream_id": "espn2",
-        "tvguide_id": "9200016131",
-        "ustvgo_id": "ESPN2",
-        "name": "ESPN2",
-        "category": "Sports",
-        "language": "en"
-    },
-    {
-        "id": 10,
-        "stream_id": "espn-news",
-        "tvguide_id": "9200006523",
-        "ustvgo_id": "ESPNews",
-        "name": "ESPNews",
-        "category": "Sports",
-        "language": "en"
-    },
-    {
-        "id": 11,
-        "stream_id": "espnu",
-        "tvguide_id": "9233011350",
-        "ustvgo_id": "ESPNU",
-        "name": "ESPNU",
-        "category": "Sports",
-        "language": "en"
-    },
-    {
-        "id": 12,
-        "stream_id": "freeform-abc-family",
-        "tvguide_id": "9200000497",
-        "ustvgo_id": "Freeform",
-        "name": "Freeform",
+        "id": 32,
+        "stream_id": "diy-network",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "DIY",
+        "name": "DIY Network",
         "category": "Entertainment",
         "language": "en"
     },
     {
-        "id": 13,
-        "stream_id": "mtv",
-        "tvguide_id": "9233015501",
-        "ustvgo_id": "MTV",
-        "name": "MTV",
+        "id": 33,
+        "stream_id": "national-geographic",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "National",
+        "name": "National Geographic",
         "category": "Entertainment",
         "language": "en"
     },
     {
-        "id": 14,
-        "stream_id": "paramount-network-spike",
-        "tvguide_id": "9233001931",
-        "ustvgo_id": "Paramount",
-        "name": "Paramount Network",
+        "id": 34,
+        "stream_id": "nba-tv-04192021",
+        "tvguide_id": "9233011874",
+        "ustvgo_id": "NBA",
+        "name": "NBA TV",
         "category": "Entertainment",
-        "language": "en"
-    },
-    {
-        "id": 15,
-        "stream_id": "sec-network",
-        "tvguide_id": "9233002484",
-        "ustvgo_id": "SECN",
-        "name": "SEC Network",
-        "category": "Sports",
-        "language": "en"
-    },
-    {
-        "id": 16,
-        "stream_id": "tvland",
-        "tvguide_id": "9233005468",
-        "ustvgo_id": "TVLand",
-        "name": "TV Land",
-        "category": "Entertainment",
-        "language": "en"
-    },
-    {
-        "id": 17,
-        "stream_id": "vh1",
-        "tvguide_id": "9233000037",
-        "ustvgo_id": "VH1",
-        "name": "VH1",
-        "category": "Lifestyle",
         "language": "en"
     }
 ]


### PR DESCRIPTION
more channels added

[
    {
        "id": 1,
        "stream_id": "ae",
        "tvguide_id": "9233011874",
        "ustvgo_id": "A&E",
        "name": "A&E",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 2,
        "stream_id": "abc",
        "tvguide_id": "9233011874",
        "ustvgo_id": "ABC",
        "name": "ABC",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 3,
        "stream_id": "cbs",
        "tvguide_id": "9233011874",
        "ustvgo_id": "CBS",
        "name": "CBS",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 4,
        "stream_id": "espn-20220618",
        "tvguide_id": "9233011874",
        "ustvgo_id": "ESPN",
        "name": "ESPN",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 5,
        "stream_id": "espn-news",
        "tvguide_id": "9233011874",
        "ustvgo_id": "ESPNNews",
        "name": "ESPN News",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 6,
        "stream_id": "espn2-20220717",
        "tvguide_id": "9233011874",
        "ustvgo_id": "ESPN2",
        "name": "ESPN2",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 7,
        "stream_id": "espnu-20220717",
        "tvguide_id": "9233011874",
        "ustvgo_id": "ESPNU",
        "name": "ESPNU",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 8,
        "stream_id": "fox-network",
        "tvguide_id": "9233011874",
        "ustvgo_id": "FOX",
        "name": "FOX",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 9,
        "stream_id": "fox-news-hd",
        "tvguide_id": "9233011874",
        "ustvgo_id": "FOXNEWS",
        "name": "Fox News",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 10,
        "stream_id": "fox-sports-1-20220618",
        "tvguide_id": "9233011874",
        "ustvgo_id": "FS1",
        "name": "FS1",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 11,
        "stream_id": "fox-sports-2-20220618",
        "tvguide_id": "9233011874",
        "ustvgo_id": "FS2",
        "name": "FS2",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 12,
        "stream_id": "golf-channel",
        "tvguide_id": "9233011874",
        "ustvgo_id": "Golf",
        "name": "Golf Channel",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 13,
        "stream_id": "hgtv",
        "tvguide_id": "9233011874",
        "ustvgo_id": "HGTV",
        "name": "HGTV",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 14,
        "stream_id": "history-channel",
        "tvguide_id": "9233011874",
        "ustvgo_id": "History",
        "name": "History Channel",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 15,
        "stream_id": "fx-live",
        "tvguide_id": "9233011874",
        "ustvgo_id": "FX",
        "name": "FX",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 16,
        "stream_id": "hbo-02032021",
        "tvguide_id": "9233011874",
        "ustvgo_id": "HBO",
        "name": "HBO",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 17,
        "stream_id": "nbc-20201017",
        "tvguide_id": "9233011874",
        "ustvgo_id": "NBC",
        "name": "NBC",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 18,
        "stream_id": "nbcsn-20201106",
        "tvguide_id": "9233011874",
        "ustvgo_id": "NBCSN",
        "name": "NBC Sports",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 19,
        "stream_id": "nfl-network",
        "tvguide_id": "9233011874",
        "ustvgo_id": "NFL",
        "name": "NFL Network",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 20,
        "stream_id": "nhl-network",
        "tvguide_id": "9233011874",
        "ustvgo_id": "NHL",
        "name": "NHL Network",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 21,
        "stream_id": "sec-network",
        "tvguide_id": "9233011874",
        "ustvgo_id": "SEC",
        "name": "SEC Network",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 22,
        "stream_id": "showtime",
        "tvguide_id": "9233011874",
        "ustvgo_id": "Showtime",
        "name": "Showtime",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 23,
        "stream_id": "starz",
        "tvguide_id": "9233011874",
        "ustvgo_id": "Starz",
        "name": "Starz",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 24,
        "stream_id": "tbs",
        "tvguide_id": "9233011874",
        "ustvgo_id": "TBS",
        "name": "TBS",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 25,
        "stream_id": "tnt",
        "tvguide_id": "9233011874",
        "ustvgo_id": "TNT",
        "name": "TNT",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 26,
        "stream_id": "travel-channel",
        "tvguide_id": "9233011874",
        "ustvgo_id": "Travel",
        "name": "Travel Channel",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 27,
        "stream_id": "trutv",
        "tvguide_id": "9233011874",
        "ustvgo_id": "TruTV",
        "name": "TruTV",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 28,
        "stream_id": "usa-network",
        "tvguide_id": "9233011874",
        "ustvgo_id": "USA",
        "name": "USA",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 29,
        "stream_id": "amc",
        "tvguide_id": "9233011874",
        "ustvgo_id": "AMC",
        "name": "AMC",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 30,
        "stream_id": "animal-planet-20211102",
        "tvguide_id": "9233011874",
        "ustvgo_id": "Animal",
        "name": "Animal Planet",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 31,
        "stream_id": "comedy-central",
        "tvguide_id": "9233011874",
        "ustvgo_id": "Comedy",
        "name": "Comedy Central",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 32,
        "stream_id": "diy-network",
        "tvguide_id": "9233011874",
        "ustvgo_id": "DIY",
        "name": "DIY Network",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 33,
        "stream_id": "national-geographic",
        "tvguide_id": "9233011874",
        "ustvgo_id": "National",
        "name": "National Geographic",
        "category": "Entertainment",
        "language": "en"
    },
    {
        "id": 34,
        "stream_id": "nba-tv-04192021",
        "tvguide_id": "9233011874",
        "ustvgo_id": "NBA",
        "name": "NBA TV",
        "category": "Entertainment",
        "language": "en"
    }
]